### PR TITLE
fix(ios): update `borderWidth` and `borderRadius` property types

### DIFF
--- a/ios/ExpoSquircleViewModule.swift
+++ b/ios/ExpoSquircleViewModule.swift
@@ -11,10 +11,10 @@ public class ExpoSquircleViewModule: Module {
             Prop("borderColor") { (view: ExpoSquircleView, prop: UIColor) in
                 view.setBorderColor(prop)
             }
-            Prop("borderWidth") { (view: ExpoSquircleView, prop: Int) in
+            Prop("borderWidth") { (view: ExpoSquircleView, prop: Float) in
                 view.setBorderWidth(CGFloat(prop))
             }
-            Prop("borderRadius") { (view: ExpoSquircleView, prop: Int) in
+            Prop("borderRadius") { (view: ExpoSquircleView, prop: Float) in
                 view.setRadius(CGFloat(prop))
             }
             Prop("cornerSmoothing") { (view: ExpoSquircleView, prop: Int) in


### PR DESCRIPTION
Right now, the borderWidth and borderRadius properties only accept `Int`, but they should instead accept `Float`

Example of the error:

https://github.com/user-attachments/assets/994850a5-5fa5-45fc-96d5-ac764f971297

